### PR TITLE
Ignore flex set to none

### DIFF
--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -1,7 +1,7 @@
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
         if(decl.value === 'none'){
-            decl.value = '0 0 auto';
+            return;
         }
     }
 };

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -6,12 +6,11 @@ describe('bug 6', function() {
         var output = 'div{flex: 1 1 auto;}';
         test(input, output, {}, done);
     });
-    it('Set flex 0 0 auto when none', function(done) {
-        var input = 'div{flex: none;}';
-        var output = 'div{flex: 0 0 auto;}';
-        test(input, output, {}, done);
-    });
     describe('does nothing', function() {
+        it('when flex is set to none', function (done) {
+            var css = 'div{flex: none;}';
+            test(css, css, {}, done);
+        });
         it('when not flex declarations', function(done) {
             var css = 'a{display: flex;}';
             test(css, css, {}, done);


### PR DESCRIPTION
Internet Explorer 11+ correctly interprets `none` as `0 0 auto`. Bug 6 is actually two-fold:

1. the value of flex is `none`, which is `0 0 auto`, while it should be `0 1 auto`, i.e. `initial` in other browsers, **but** if we set `flex` explicitly to `none`, it will be correctly interpreted as `0 0 auto` in all browsers
2. if `flex-shrink` is not specified in a `flex` declaration, it defaults to `0` instead of `1`

There's nothing we can do about 1.) because the problem isn't the `none` value itself, it's that `none` is the initial value. It's 2.) part that we're fixing.

Unless I'm wrong about this, the [flexbugs](https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed) docs needs to separate that bug into a) and b). But baby steps :baby: 

Also failing test for now, will fix the code soon.