### PR TITLE
Chore: [breaking changes] minimum required `postcss` version is now `^6.0.1`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url":  "https://github.com/luisrudge/postcss-flexbugs-fixes.git"
     },
     "dependencies": {
-        "postcss": "^5.0.0"
+        "postcss": "^6.0.1"
     },
     "main": "index.js",
     "files": [


### PR DESCRIPTION
Need major release :+1: 