### PR TITLE
Fix tests for Safari fix

### DIFF
--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -6,6 +6,10 @@ module.exports = function(decl) {
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || '0%';
+        // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
+        // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
+        // already defined somewhere else.
+        if(flexBasis == '0%') flexBasis = '';
         decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -9,7 +9,7 @@ module.exports = function(decl) {
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.
-        if(flexBasis == '0%') flexBasis = '';
+        if(flexBasis === '0%') flexBasis = '';
         decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -9,7 +9,7 @@ module.exports = function(decl) {
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.
-        if(flexBasis === '0%') flexBasis = '';
-        decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
+        if(flexBasis === '0%') flexBasis = null;
+        decl.value = flexGrow + ' ' + flexShrink + ((flexBasis)?' ' + flexBasis:'');
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -10,6 +10,6 @@ module.exports = function(decl) {
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.
         if(flexBasis === '0%') flexBasis = null;
-        decl.value = flexGrow + ' ' + flexShrink + ((flexBasis)?' ' + flexBasis:'');
+        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
     }
 };

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -3,27 +3,27 @@ var test = require('./test');
 describe('bug 4', function() {
     it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1 0%;}';
+        var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
     it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1 0%;}';
+        var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
     it('set 0% for default flex-basis when not specified', function(done) {
         var input = 'div{flex: 1 1;}';
-        var output = 'div{flex: 1 1 0%;}';
+        var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
     it('set flex-basis === 0% for flex-basis with plain 0', function(done) {
         var input = 'div{flex: 1 0 0;}';
-        var output = 'div{flex: 1 0 0%;}';
+        var output = 'div{flex: 1 0;}';
         test(input, output, {}, done);
     });
     it('set flex-basis === 0% for flex-basis with 0px', function(done) {
         var input = 'div{flex: 1 0 0px;}';
-        var output = 'div{flex: 1 0 0%;}';
+        var output = 'div{flex: 1 0;}';
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
@@ -32,7 +32,7 @@ describe('bug 4', function() {
             test(css, css, {}, done);
         });
         it('when flex-basis with percent is set', function(done) {
-            var css = 'div{flex: 1 0 0%;}';
+            var css = 'div{flex: 1 0 100%;}';
             test(css, css, {}, done);
         });
         it('when flex-basis with pixels is set', function(done) {

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -3,7 +3,7 @@ var test = require('./test');
 describe('bug 6', function() {
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1 0%;}';
+        var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
@@ -17,11 +17,13 @@ describe('bug 6', function() {
         });
         it('when flex-shrink is set explicitly to zero', function(done) {
             var css = 'div{flex: 1 0 0%;}';
-            test(css, css, {}, done);
+            var output = 'div{flex: 1 0;}';
+            test(css, output, {}, done);
         });
         it('when flex-shrink is set explicitly to non-zero value', function(done) {
             var css = 'div{flex: 1 2 0%}';
-            test(css, css, {}, done);
+            var output = 'div{flex: 1 2}';
+            test(css, output, {}, done);
         });
         describe('when flex value is reserved word', function() {
             var stringValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];

--- a/specs/bug81aSpec.js
+++ b/specs/bug81aSpec.js
@@ -9,12 +9,12 @@ describe('bug 8.1.a', function() {
     describe('does nothing', function() {
         it('when using only first value', function(done) {
             var input = 'a{flex: 0}';
-            var output = 'a{flex: 0 1 0%}';
+            var output = 'a{flex: 0 1}';
             test(input, output, {}, done);
         });
         it('when using only first and second values', function(done) {
             var input = 'a{flex: 0 0}';
-            var output = 'a{flex: 0 0 0%}';
+            var output = 'a{flex: 0 0}';
             test(input, output, {}, done);
         });
         it('when not using calc', function(done) {


### PR DESCRIPTION
Fixes up the tests based on @subdigit's [fix](https://github.com/luisrudge/postcss-flexbugs-fixes/pull/38). Some of the tests don't _totally_ make sense anymore, i.e `does nothing` should still remove the basis value, so it's not technically doing nothing. All checks are green now.