### PR TITLE
Set flex basis if second value is not a number

### DIFF
--- a/bugs/bug4.js
+++ b/bugs/bug4.js
@@ -17,9 +17,28 @@ function properBasis(basis) {
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
         var values = postcss.list.space(decl.value);
-        var flexGrow = values[0];
-        var flexShrink = values[1] || '1';
-        var flexBasis = values[2] || '0%';
+
+        // set default values
+        var flexGrow = '0';
+        var flexShrink = '1';
+        var flexBasis = '0%';
+
+        if (values[0]) {
+            flexGrow = values[0];
+        }
+
+        if (values[1]) {
+            if (!isNaN(values[1])) {
+                flexShrink = values[1];
+            } else {
+                flexBasis = values[1];
+            }
+        }
+
+        if (values[2]) {
+            flexBasis = values[2];
+        }
+
         decl.value = flexGrow + ' ' + flexShrink + ' ' + properBasis(flexBasis);
     }
 };

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -26,6 +26,11 @@ describe('bug 4', function() {
         var output = 'div{flex: 1 0;}';
         test(input, output, {}, done);
     });
+    it('set flex-basis when second value is not a number', function(done) {
+        var input = 'div{flex: 1 50%;}';
+        var output = 'div{flex: 1 1 50%;}';
+        test(input, output, {}, done);
+    });
     describe('does nothing', function() {
         it('when not flex declarations', function(done) {
             var css = 'a{display: flex;}';


### PR DESCRIPTION
If the second value is not a number then it is the flex-basis, not the flex-shrink. See issue #39 