### PR TITLE
Add option to disable bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@
 postcss([require('postcss-flexbugs-fixes')]);
 ```
 
+You can also disable bugs individually, possible keys `bug4`, `bug6` and `bug8a`.
+```js
+var plugin = require('postcss-flexbugs-fixes');
+postcss([plugin({ bug6: false })]);
+```
+
 See [PostCSS] docs for examples for your environment.
 
 [postcss]: https://github.com/postcss/postcss

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var bug81a = require('./bugs/bug81a');
 var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
 
 module.exports = postcss.plugin('postcss-flexbugs-fixes', function (opts) {
-    opts = opts || {};
+    var options = Object.assign({ bug4: true, bug6: true, bug81a: true }, opts);
 
     return function (css) {
         css.walkDecls(function (d) {
@@ -17,9 +17,15 @@ module.exports = postcss.plugin('postcss-flexbugs-fixes', function (opts) {
             if (doNothingValues.indexOf(d.value) > 0 && values.length === 1) {
                 return;
             }
-            bug4(d);
-            bug6(d);
-            bug81a(d);
+            if (options.bug4) {
+                bug4(d);
+            }
+            if (options.bug6) {
+                bug6(d);
+            }
+            if (options.bug81a) {
+                bug81a(d);
+            }
         });
     };
 });

--- a/specs/pluginSpec.js
+++ b/specs/pluginSpec.js
@@ -1,0 +1,9 @@
+var test = require('./test');
+
+describe('plugin options', function() {
+    it('allows to disable bug fixes', function(done) {
+        var input = 'div{flex: 1;}';
+        var output = 'div{flex: 1;}';
+        test(input, output, { bug4: false, bug6: false, bug8a: false }, done);
+    });
+});


### PR DESCRIPTION
I really don't like that `bug6` removes `0%` because it breaks `flex: 1;` in IE (`bug4`).
So instead of rewriting `bug6` I added the possibility to disable bugs fixes.

Closes #13