### PR TITLE
Fix `initial` and `auto` value for flex

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 ### Input
 
 ```css
-.foo { flex: 1; }
-.bar { flex: 1 1; }
 .foz { flex: 1 1 0; }
 .baz { flex: 1 1 0px; }
 ```
@@ -14,10 +12,8 @@
 ### Output
 
 ```css
-.foo { flex: 1 1; }
-.bar { flex: 1 1; }
-.foz { flex: 1 1; }
-.baz { flex: 1 1; }
+.foz { flex: 1 1 0%; }
+.baz { flex: 1 1 0%; }
 ```
 
 ## bug [6](https://github.com/philipwalton/flexbugs/blob/master/README.md#6-the-default-flex-value-has-changed)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 }
 ```
 
-## bug [8.1.a](https://github.com/philipwalton/flexbugs/blob/master/README.md#8-flex-basis-doesnt-support-calc)
+## bug [8](https://github.com/philipwalton/flexbugs/blob/master/README.md#8-flex-basis-doesnt-support-calc)
 ### Input
 
 ```css

--- a/bugs/bug4.js
+++ b/bugs/bug4.js
@@ -18,7 +18,7 @@ function properBasis(basis) {
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
         var values = postcss.list.space(decl.value);
-        if (doNothingValues.instanceOf(decl.value) > -1 && values.length === 1) {
+        if (doNothingValues.indexOf(decl.value) > -1 && values.length === 1) {
             return;
         }
 

--- a/bugs/bug4.js
+++ b/bugs/bug4.js
@@ -1,4 +1,5 @@
 var postcss = require('postcss');
+var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
 
 function shouldSetZeroBasis(basisValue) {
     if (!basisValue) {
@@ -17,6 +18,9 @@ function properBasis(basis) {
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
         var values = postcss.list.space(decl.value);
+        if (doNothingValues.instanceOf(decl.value) > -1 && values.length === 1) {
+            return;
+        }
 
         // set default values
         var flexGrow = '0';

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,14 +2,19 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
+        if (decl.value === 'initial') {
+          decl.value = '0 1 auto';
+        }
+        if (decl.value === 'auto') {
+          decl.value = '1 1 auto';
+        }
+        if (decl.value === '1') {
+          decl.value = '1 1 0%';
+        }
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || '0%';
-        if (flexGrow === 'initial') {
-            decl.value = '0 1 auto';
-            return;
-        }
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,6 +2,10 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
+        if (decl.value === 'initial') {
+            decl.value = '0 1 auto';
+            return;
+        }
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -4,12 +4,11 @@ module.exports = function(decl) {
     if (decl.prop === 'flex') {
         if (decl.value === 'initial') {
             decl.value = '0 1 auto';
+            return;
         }
         if (decl.value === 'auto') {
             decl.value = '1 1 auto';
-        }
-        if (decl.value === '1') {
-            decl.value = '1 1 0%';
+            return;
         }
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -7,9 +7,8 @@ module.exports = function(decl) {
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || 'auto';
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
-        // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
-        // already defined somewhere else.
-        if (flexBasis === '0%' || flexBasis === '0px') flexBasis = 'auto';
-        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
+        // so if we see a '0%' or '0px', normalize it to '0'.
+        if (flexBasis === '0%' || flexBasis === '0px') flexBasis = '0';
+        decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -9,10 +9,10 @@ module.exports = function(decl) {
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
-        var flexBasis = values[2] || 'auto';
+        var flexBasis = values[2] || '0%';
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%' or '0px', normalize it to '0'.
-        if (flexBasis === '0%' || flexBasis === '0px') flexBasis = '0';
+        if (flexBasis === '0' || flexBasis === '0%' ||flexBasis === '0px') flexBasis = '0';
         decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -5,11 +5,11 @@ module.exports = function(decl) {
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
-        var flexBasis = values[2] || '0%';
+        var flexBasis = values[2] || 'auto';
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.
-        if(flexBasis === '0%') flexBasis = null;
+        if (flexBasis === '0%' || flexBasis === '0px') flexBasis = 'auto';
         decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -11,8 +11,9 @@ module.exports = function(decl) {
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || '0%';
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
-        // so if we see a '0%' or '0px', normalize it to '0'.
-        if (flexBasis === '0' || flexBasis === '0%' ||flexBasis === '0px') flexBasis = '0';
-        decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
+        // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
+        // already defined somewhere else.
+        if(flexBasis === '0%') flexBasis = null;
+        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,14 +2,14 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
-        if (decl.value === 'initial') {
-            decl.value = '0 1 auto';
-            return;
-        }
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || '0%';
+        if (flexGrow === 'initial') {
+            decl.value = '0 1 auto';
+            return;
+        }
         // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
         // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
         // already defined somewhere else.

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -1,4 +1,5 @@
 var postcss = require('postcss');
+var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
@@ -11,6 +12,9 @@ module.exports = function(decl) {
             return;
         }
         var values = postcss.list.space(decl.value);
+        if (doNothingValues.indexOf(decl.value) > -1 && values.langth === 1) {
+            return;
+        }
         var flexGrow = values[0];
         var flexShrink = values[1] || '1';
         var flexBasis = values[2] || '0%';

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -3,13 +3,13 @@ var postcss = require('postcss');
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
         if (decl.value === 'initial') {
-          decl.value = '0 1 auto';
+            decl.value = '0 1 auto';
         }
         if (decl.value === 'auto') {
-          decl.value = '1 1 auto';
+            decl.value = '1 1 auto';
         }
         if (decl.value === '1') {
-          decl.value = '1 1 0%';
+            decl.value = '1 1 0%';
         }
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];

--- a/bugs/bug81a.js
+++ b/bugs/bug81a.js
@@ -1,8 +1,12 @@
 var postcss = require('postcss');
+var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
 
 module.exports = function(decl) {
     var regex = /(\d{1,}) (\d{1,}) (calc\(.*?\))/g;
     var matches = regex.exec(decl.value);
+    if (doNothingValues.instanceOf(decl.value) > -1 && matches.length === 1) {
+        return;
+    }
     if (decl.prop === 'flex' && matches) {
         var grow = postcss.decl({
             prop: 'flex-grow',

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var bug4 = require('./bugs/bug4');
 var bug6 = require('./bugs/bug6');
 var bug81a = require('./bugs/bug81a');
 
-var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
+var doNothingValues = ['none', 'content', 'inherit', 'unset'];
 
 module.exports = postcss.plugin('postcss-flexbugs-fixes', function (opts) {
     var options = Object.assign({ bug4: true, bug6: true, bug81a: true }, opts);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var bug4 = require('./bugs/bug4');
 var bug6 = require('./bugs/bug6');
 var bug81a = require('./bugs/bug81a');
 
-var doNothingValues = ['none', 'content', 'inherit', 'unset'];
+var doNothingValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
 
 module.exports = postcss.plugin('postcss-flexbugs-fixes', function (opts) {
     var options = Object.assign({ bug4: true, bug6: true, bug81a: true }, opts);
@@ -13,15 +13,15 @@ module.exports = postcss.plugin('postcss-flexbugs-fixes', function (opts) {
             if (d.value === 'none') {
                 return;
             }
+            if (options.bug6) {
+                bug6(d);
+            }
             var values = postcss.list.space(d.value);
             if (doNothingValues.indexOf(d.value) > 0 && values.length === 1) {
                 return;
             }
             if (options.bug4) {
                 bug4(d);
-            }
-            if (options.bug6) {
-                bug6(d);
             }
             if (options.bug81a) {
                 bug81a(d);

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -1,21 +1,6 @@
 var test = require('./test');
 
 describe('bug 4', function() {
-    it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
-        var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1 0%;}';
-        test(input, output, {}, done);
-    });
-    it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
-        var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1 0%;}';
-        test(input, output, {}, done);
-    });
-    it('set 0% for default flex-basis when not specified', function(done) {
-        var input = 'div{flex: 1 1;}';
-        var output = 'div{flex: 1 1 0%;}';
-        test(input, output, {}, done);
-    });
     it('set flex-basis === 0% for flex-basis with plain 0', function(done) {
         var input = 'div{flex: 1 0 0;}';
         var output = 'div{flex: 1 0 0%;}';
@@ -32,10 +17,6 @@ describe('bug 4', function() {
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
-        it('when not flex declarations', function(done) {
-            var css = 'a{display: flex;}';
-            test(css, css, {}, done);
-        });
         it('when flex-basis with percent is set', function(done) {
             var css = 'div{flex: 1 0 100%;}';
             test(css, css, {}, done);

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -3,27 +3,27 @@ var test = require('./test');
 describe('bug 4', function() {
     it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0%;}';
         test(input, output, {}, done);
     });
     it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0%;}';
         test(input, output, {}, done);
     });
     it('set 0% for default flex-basis when not specified', function(done) {
         var input = 'div{flex: 1 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0%;}';
         test(input, output, {}, done);
     });
     it('set flex-basis === 0% for flex-basis with plain 0', function(done) {
         var input = 'div{flex: 1 0 0;}';
-        var output = 'div{flex: 1 0;}';
+        var output = 'div{flex: 1 0 0%;}';
         test(input, output, {}, done);
     });
     it('set flex-basis === 0% for flex-basis with 0px', function(done) {
         var input = 'div{flex: 1 0 0px;}';
-        var output = 'div{flex: 1 0;}';
+        var output = 'div{flex: 1 0 0%;}';
         test(input, output, {}, done);
     });
     it('set flex-basis when second value is not a number', function(done) {
@@ -40,16 +40,12 @@ describe('bug 4', function() {
             var css = 'div{flex: 1 0 100%;}';
             test(css, css, {}, done);
         });
-        it('when flex-basis with pixels is set', function(done) {
-            var css = 'div{flex: 1 0 10px;}';
-            test(css, css, {}, done);
-        });
         it('doen not change auto flex-basis is set explicitly', function(done) {
             var css = 'div{flex: 1 1 auto;}';
             test(css, css, {}, done);
         });
         describe('when flex value is reserved word', function() {
-            var stringValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
+            var stringValues = ['none', 'content', 'inherit', 'unset'];
             stringValues.forEach(function(s) {
                 it(s, function(done) {
                     var input = 'div{flex: ' + s + ';}';

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -13,22 +13,22 @@ describe('bug 6', function() {
     });
     it('Fix value when `flex:1`', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0%;}';
         test(input, output, {}, done);
     });
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0%;}';
         test(input, output, {}, done);
     });
     it('when flex-shrink is set explicitly to zero', function(done) {
         var css = 'div{flex: 1 0 0%;}';
-        var output = 'div{flex: 1 0;}';
+        var output = 'div{flex: 1 0 0%;}';
         test(css, output, {}, done);
     });
     it('when flex-shrink is set explicitly to non-zero value', function(done) {
         var css = 'div{flex: 1 2 0%}';
-        var output = 'div{flex: 1 2}';
+        var output = 'div{flex: 1 2 0%}';
         test(css, output, {}, done);
     });
     describe('does nothing', function() {

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -21,6 +21,16 @@ describe('bug 6', function() {
         var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
+    it('when flex-shrink is set explicitly to zero', function(done) {
+        var css = 'div{flex: 1 0 0%;}';
+        var output = 'div{flex: 1 0;}';
+        test(css, output, {}, done);
+    });
+    it('when flex-shrink is set explicitly to non-zero value', function(done) {
+        var css = 'div{flex: 1 2 0%}';
+        var output = 'div{flex: 1 2}';
+        test(css, output, {}, done);
+    });
     describe('does nothing', function() {
         it('when flex is set to none', function (done) {
             var css = 'div{flex: none;}';
@@ -30,18 +40,8 @@ describe('bug 6', function() {
             var css = 'a{display: flex;}';
             test(css, css, {}, done);
         });
-        it('when flex-shrink is set explicitly to zero', function(done) {
-            var css = 'div{flex: 1 0 0%;}';
-            var output = 'div{flex: 1 0;}';
-            test(css, output, {}, done);
-        });
-        it('when flex-shrink is set explicitly to non-zero value', function(done) {
-            var css = 'div{flex: 1 2 0%}';
-            var output = 'div{flex: 1 2}';
-            test(css, output, {}, done);
-        });
         describe('when flex value is reserved word', function() {
-            var stringValues = ['none', 'auto', 'content', 'inherit', 'unset'];
+            var stringValues = ['none', 'content', 'inherit', 'unset'];
             stringValues.forEach(function(s) {
                 it(s, function(done) {
                     var input = 'div{flex: ' + s + ';}';

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -1,6 +1,11 @@
 var test = require('./test');
 
 describe('bug 6', function() {
+    it('Set flex for initial value', function(done) {
+        var input = 'div{flex: initial;}';
+        var output = 'div{flex: 0 1 auto;}';
+        test(input, output, {}, done);
+    });
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
         var output = 'div{flex: 1 1;}';

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -32,10 +32,6 @@ describe('bug 6', function() {
         test(css, output, {}, done);
     });
     describe('does nothing', function() {
-        it('when flex is set to none', function (done) {
-            var css = 'div{flex: none;}';
-            test(css, css, {}, done);
-        });
         it('when not flex declarations', function(done) {
             var css = 'a{display: flex;}';
             test(css, css, {}, done);

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -31,7 +31,7 @@ describe('bug 6', function() {
             test(css, output, {}, done);
         });
         describe('when flex value is reserved word', function() {
-            var stringValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
+            var stringValues = ['none', 'auto', 'content', 'inherit', 'unset'];
             stringValues.forEach(function(s) {
                 it(s, function(done) {
                     var input = 'div{flex: ' + s + ';}';

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -1,9 +1,19 @@
 var test = require('./test');
 
 describe('bug 6', function() {
-    it('Set flex for initial value', function(done) {
+    it('Fix value when `flex:initial`', function(done) {
         var input = 'div{flex: initial;}';
         var output = 'div{flex: 0 1 auto;}';
+        test(input, output, {}, done);
+    });
+    it('Fix value when `flex:auto`', function(done) {
+        var input = 'div{flex: auto;}';
+        var output = 'div{flex: 1 1 auto;}';
+        test(input, output, {}, done);
+    });
+    it('Fix value when `flex:1`', function(done) {
+        var input = 'div{flex: 1;}';
+        var output = 'div{flex: 1 1;}';
         test(input, output, {}, done);
     });
     it('Set flex-shrink to 1 by default', function(done) {

--- a/specs/bug81aSpec.js
+++ b/specs/bug81aSpec.js
@@ -7,22 +7,12 @@ describe('bug 8.1.a', function() {
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
-        it('when using only first value', function(done) {
-            var input = 'a{flex: 0}';
-            var output = 'a{flex: 0 1}';
-            test(input, output, {}, done);
-        });
-        it('when using only first and second values', function(done) {
-            var input = 'a{flex: 0 0}';
-            var output = 'a{flex: 0 0}';
-            test(input, output, {}, done);
-        });
         it('when not using calc', function(done) {
-            var css = 'a{flex: 0 0 1px}';
+            var css = 'a{flex: 0 0 0%}';
             test(css, css, {}, done);
         });
         describe('when flex value is reserved word', function() {
-            var stringValues = ['none', 'auto', 'content', 'inherit', 'initial', 'unset'];
+            var stringValues = ['none', 'content', 'inherit', 'unset'];
             stringValues.forEach(function(s) {
                 it(s, function(done) {
                     var input = 'div{flex: ' + s + ';}';


### PR DESCRIPTION
This PR to handle the `initial` and `auto` value for `flex` CSS property

`flex: initial → flex: 0 1 auto`
`flex: auto → flex: 1 1 auto`

https://github.com/luisrudge/postcss-flexbugs-fixes/issues/48