### PR TITLE
We do have to expand `flex` values

### DIFF
--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,7 +2,7 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
-		var list = postcss.list.space(decl.value);
+        var list = postcss.list.space(decl.value);
         var values = ['0', '1', '0%'];
         list.reduce(function (obj, value, key) {
             if (/%/.test(value) || /px/.test(value)) {

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,34 +2,18 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
-        var values = postcss.list.space(decl.value);
+        var values = postcss.list.space(decl.value).reduce(function (obj, value, key) {
+            if (/%/.test(value)) {
+                obj[2] = value;
+            } else {
+                obj[key] = value;
+            }
+            return obj;
+        }, ['0', '1', '0%']);
         var flexGrow = values[0];
-        var flexShrink = values[1] || '1';
+        var flexShrink = values[1];
         var flexBasis = values[2];
-        if (flexGrow){
-            var grow = postcss.decl({
-                prop: 'flex-grow',
-                value: flexGrow,
-                source: decl.source
-            });
-            decl.parent.insertBefore(decl, grow);
-        }
-        if (flexShrink){
-            var shrink = postcss.decl({
-                prop: 'flex-shrink',
-                value: flexShrink,
-                source: decl.source
-            });
-            decl.parent.insertBefore(decl, shrink);
-        }
-        if (flexBasis){
-            var basis = postcss.decl({
-                prop: 'flex-basis',
-                value: flexBasis,
-                source: decl.source
-            });
-            decl.parent.insertBefore(decl, basis);
-        }
-        decl.remove();
+        if(flexBasis === '0px' || flexBasis === '0') flexBasis = '0%';
+        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -14,6 +14,6 @@ module.exports = function(decl) {
         var flexShrink = values[1];
         var flexBasis = values[2];
         if(flexBasis === '0px' || flexBasis === '0') flexBasis = '0%';
-        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
+        decl.value = flexGrow + ' ' + flexShrink + ' ' + flexBasis;
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -4,7 +4,7 @@ module.exports = function(decl) {
     if (decl.prop === 'flex') {
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
-        var flexShrink = values[1];
+        var flexShrink = values[1] || '1';
         var flexBasis = values[2];
         if (flexGrow){
             var grow = postcss.decl({

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -4,12 +4,32 @@ module.exports = function(decl) {
     if (decl.prop === 'flex') {
         var values = postcss.list.space(decl.value);
         var flexGrow = values[0];
-        var flexShrink = values[1] || '1';
-        var flexBasis = values[2] || '0%';
-        // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
-        // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
-        // already defined somewhere else.
-        if(flexBasis === '0%') flexBasis = null;
-        decl.value = flexGrow + ' ' + flexShrink + (flexBasis ? ' ' + flexBasis : '');
+        var flexShrink = values[1];
+        var flexBasis = values[2];
+        if (flexGrow){
+            var grow = postcss.decl({
+                prop: 'flex-grow',
+                value: flexGrow,
+                source: decl.source
+            });
+            decl.parent.insertBefore(decl, grow);
+        }
+        if (flexShrink){
+            var shrink = postcss.decl({
+                prop: 'flex-shrink',
+                value: flexShrink,
+                source: decl.source
+            });
+            decl.parent.insertBefore(decl, shrink);
+        }
+        if (flexBasis){
+            var grow = postcss.decl({
+                prop: 'flex-basis',
+                value: flexBasis,
+                source: decl.source
+            });
+            decl.parent.insertBefore(decl, basis);
+        }
+        decl.remove();
     }
 };

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -11,7 +11,7 @@ module.exports = function(decl) {
                 values[key] = value;
             }
             return obj;
-        });
+        }, list);
         var flexGrow = values[0];
         var flexShrink = values[1];
         var flexBasis = values[2];

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,7 +2,8 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
-        var values = postcss.list.space(decl.value).reduce(function (obj, value, key) {
+        var list = postcss.list.space(decl.value);
+        var values = list.reduce(function (obj, value, key) {
             if (/%/.test(value)) {
                 obj[2] = value;
             } else {

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -2,15 +2,16 @@ var postcss = require('postcss');
 
 module.exports = function(decl) {
     if (decl.prop === 'flex') {
-        var list = postcss.list.space(decl.value);
-        var values = list.reduce(function (obj, value, key) {
-            if (/%/.test(value)) {
-                obj[2] = value;
+		var list = postcss.list.space(decl.value);
+        var values = ['0', '1', '0%'];
+        list.reduce(function (obj, value, key) {
+            if (/%/.test(value) || /px/.test(value)) {
+                values[2] = value.replace(/px/, '%');
             } else {
-                obj[key] = value;
+                values[key] = value;
             }
             return obj;
-        }, ['0', '1', '0%']);
+        });
         var flexGrow = values[0];
         var flexShrink = values[1];
         var flexBasis = values[2];

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -23,7 +23,7 @@ module.exports = function(decl) {
             decl.parent.insertBefore(decl, shrink);
         }
         if (flexBasis){
-            var grow = postcss.decl({
+            var basis = postcss.decl({
                 prop: 'flex-basis',
                 value: flexBasis,
                 source: decl.source

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -3,7 +3,17 @@ var test = require('./test');
 describe('bug 6', function() {
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex-grow: 1;flex-shrink: 1;}';
+        var output = 'div{flex: 1 1 0%;}';
+        test(input, output, {}, done);
+    });
+    it('Set flex-shrink to 1 by default', function(done) {
+        var input = 'div{flex: 1%;}';
+        var output = 'div{flex: 0 1 1%;}';
+        test(input, output, {}, done);
+    });
+    it('Set flex-shrink to 1 by default', function(done) {
+        var input = 'div{flex: 1 1%;}';
+        var output = 'div{flex: 1 1 1%;}';
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
@@ -17,17 +27,17 @@ describe('bug 6', function() {
         });
         it('when flex-shrink is set explicitly to zero', function(done) {
             var css = 'div{flex: 1 0 0%;}';
-            var output = 'div{flex-grow: 1;flex-shrink: 0;flex-basis: 0;}';
+            var output = 'div{flex: 1 0 0%;}';
             test(css, output, {}, done);
         });
         it('when flex-shrink is set explicitly to non-zero value', function(done) {
             var css = 'div{flex: 1 2 0%;}';
-            var output = 'div{flex-grow: 1;flex-shrink: 2;flex-basis: 0;}';
+            var output = 'div{flex: 1 2 0%;}';
             test(css, output, {}, done);
         });
         it('when flex-basis is not set', function(done) {
             var css = 'div{flex: 1 1;}';
-            var output = 'div{flex-grow: 1;flex-shrink: 1;}';
+            var output = 'div{flex: 1 1 0%;}';
             test(css, output, {}, done);
         });
         describe('when flex value is reserved word', function() {

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -21,8 +21,13 @@ describe('bug 6', function() {
             test(css, output, {}, done);
         });
         it('when flex-shrink is set explicitly to non-zero value', function(done) {
-            var css = 'div{flex: 1 2 0%}';
+            var css = 'div{flex: 1 2 0%;}';
             var output = 'div{flex-grow: 1;flex-shrink: 2;flex-basis: 0;}';
+            test(css, output, {}, done);
+        });
+        it('when flex-basis is not set', function(done) {
+            var css = 'div{flex: 1 1;}';
+            var output = 'div{flex-grow: 1;flex-shrink: 1;}';
             test(css, output, {}, done);
         });
         describe('when flex value is reserved word', function() {

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -3,7 +3,7 @@ var test = require('./test');
 describe('bug 6', function() {
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex-grow: 1;flex-shrink: 1;}';
         test(input, output, {}, done);
     });
     describe('does nothing', function() {
@@ -17,12 +17,12 @@ describe('bug 6', function() {
         });
         it('when flex-shrink is set explicitly to zero', function(done) {
             var css = 'div{flex: 1 0 0%;}';
-            var output = 'div{flex: 1 0;}';
+            var output = 'div{flex-grow: 1;flex-shrink: 0;flex-basis: 0;}';
             test(css, output, {}, done);
         });
         it('when flex-shrink is set explicitly to non-zero value', function(done) {
             var css = 'div{flex: 1 2 0%}';
-            var output = 'div{flex: 1 2}';
+            var output = 'div{flex-grow: 1;flex-shrink: 2;flex-basis: 0;}';
             test(css, output, {}, done);
         });
         describe('when flex value is reserved word', function() {


### PR DESCRIPTION
> `flex: 30px` means `flex: 0 0 30px` in IE10 instead of `flex: 0 1 30px`, so we do have to expand it 😕
> 
> Check out the [updated Flexbug 6](https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed).
> –  https://github.com/luisrudge/postcss-flexbugs-fixes/issues/26#issuecomment-140068813 by @silvenon

Issue: https://github.com/luisrudge/postcss-flexbugs-fixes/issues/26