### PR TITLE
BUG 4: Replace `0%` with `0px`

### DIFF
--- a/bugs/bug4.js
+++ b/bugs/bug4.js
@@ -4,12 +4,12 @@ function shouldSetZeroBasis(basisValue) {
     if (!basisValue) {
         return false;
     }
-    return basisValue === '0' || basisValue.replace(/\s/g, '') === '0px';
+    return basisValue === '0';
 }
 
 function properBasis(basis) {
     if (shouldSetZeroBasis(basis)) {
-        return '0%';
+        return '0px';
     }
     return basis;
 }
@@ -21,7 +21,7 @@ module.exports = function(decl) {
         // set default values
         var flexGrow = '0';
         var flexShrink = '1';
-        var flexBasis = '0%';
+        var flexBasis = '0px';
 
         if (values[0]) {
             flexGrow = values[0];

--- a/package.json
+++ b/package.json
@@ -2,12 +2,19 @@
     "name": "postcss-flexbugs-fixes",
     "version": "4.1.0",
     "description": "PostCSS plugin This project tries to fix all of flexbug's issues",
-    "keywords": ["postcss", "css", "postcss-plugin", "flexbugs", "flexbox", "flex"],
+    "keywords": [
+        "postcss",
+        "css",
+        "postcss-plugin",
+        "flexbugs",
+        "flexbox",
+        "flex"
+    ],
     "author": "Luis Rudge <luis@luisrudge.net>",
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url":  "https://github.com/luisrudge/postcss-flexbugs-fixes.git"
+        "url": "https://github.com/luisrudge/postcss-flexbugs-fixes.git"
     },
     "dependencies": {
         "postcss": "^7.0.0"
@@ -18,10 +25,10 @@
         "index.js"
     ],
     "devDependencies": {
+        "chai": "^2.3.0",
+        "gulp": "^3.8.11",
         "gulp-eslint": "^0.12.0",
-        "gulp-mocha":  "^2.0.1",
-        "chai":        "^2.3.0",
-        "gulp":        "^3.8.11"
+        "gulp-mocha": "^2.0.1"
     },
     "scripts": {
         "test": "gulp"

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -1,28 +1,33 @@
 var test = require('./test');
 
 describe('bug 4', function() {
-    it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
+    it('set 0px for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0px;}';
         test(input, output, {}, done);
     });
-    it('set 0% for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
+    it('set 0px for default flex-basis and 1 for flex-shrink in flex shorthand', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0px;}';
         test(input, output, {}, done);
     });
-    it('set 0% for default flex-basis when not specified', function(done) {
+    it('set 0px for default flex-basis when not specified', function(done) {
         var input = 'div{flex: 1 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0px;}';
         test(input, output, {}, done);
     });
-    it('set flex-basis === 0% for flex-basis with plain 0', function(done) {
+    it('set flex-basis === 0px for flex-basis with plain 0', function(done) {
         var input = 'div{flex: 1 0 0;}';
-        var output = 'div{flex: 1 0;}';
+        var output = 'div{flex: 1 0 0px;}';
         test(input, output, {}, done);
     });
-    it('set flex-basis === 0% for flex-basis with 0px', function(done) {
+    it('set flex-basis === 0xp for flex-basis with 0px', function(done) {
         var input = 'div{flex: 1 0 0px;}';
+        var output = 'div{flex: 1 0 0px;}';
+        test(input, output, {}, done);
+    });
+    it('set flex-basis === 0% for flex-basis with 0%', function(done) {
+        var input = 'div{flex: 1 0 0%;}';
         var output = 'div{flex: 1 0;}';
         test(input, output, {}, done);
     });

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -3,7 +3,7 @@ var test = require('./test');
 describe('bug 6', function() {
     it('Set flex-shrink to 1 by default', function(done) {
         var input = 'div{flex: 1;}';
-        var output = 'div{flex: 1 1;}';
+        var output = 'div{flex: 1 1 0px;}';
         test(input, output, {}, done);
     });
     describe('does nothing', function() {

--- a/specs/bug81aSpec.js
+++ b/specs/bug81aSpec.js
@@ -9,12 +9,12 @@ describe('bug 8.1.a', function() {
     describe('does nothing', function() {
         it('when using only first value', function(done) {
             var input = 'a{flex: 0}';
-            var output = 'a{flex: 0 1}';
+            var output = 'a{flex: 0 1 0px}';
             test(input, output, {}, done);
         });
         it('when using only first and second values', function(done) {
             var input = 'a{flex: 0 0}';
-            var output = 'a{flex: 0 0}';
+            var output = 'a{flex: 0 0 0px}';
             test(input, output, {}, done);
         });
         it('when not using calc', function(done) {


### PR DESCRIPTION
The absence of value for `flex-basis` or the presence of `0` should not be replaced with `0%` since `0%` behaves differently from `0px`.
It should instead be replaced with `0px`.
See explanation here: https://bugs.chromium.org/p/chromium/issues/detail?id=495306