### PR TITLE
Promote `postcss` to a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
         "bugs",
         "index.js"
     ],
+    "dependencies": {
+        "postcss": "^8.1.4"
+    },
     "devDependencies": {
-        "postcss": "^8.1.4",
         "chai": "^4.2.0",
         "gulp": "^4.0.2",
         "gulp-eslint": "^6.0.0",


### PR DESCRIPTION
Possibly related to #73.

`postcss-flexbugs-fixes@5` uses `postcss` at run time, so it should specify a production dependency on `postcss` - otherwise, it may end up being used in conjunction with the wrong `postcss`, or being unable to load it at all.

This could arguably be a peer dependency instead, I'd be happy to modify my PR if that's the opinion.