### PR TITLE
Bump postcss peer dep to 8.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "index.js"
     ],
     "peerDependencies": {
-        "postcss": "^8.1.4"
+        "postcss": "^8.2.15"
     },
     "devDependencies": {
         "chai": "^4.2.0",


### PR DESCRIPTION
See npm security advisory for postcss: https://www.npmjs.com/advisories/1693