### PR TITLE
Fixed flexBasis bug when it has operator wrapped by space if syntax is provided

### DIFF
--- a/bugs/bug4.js
+++ b/bugs/bug4.js
@@ -36,7 +36,7 @@ module.exports = function(decl) {
     }
 
     if (values[2]) {
-      flexBasis = values[2];
+      flexBasis = values.slice(2).join(' ');
     }
 
     decl.value = flexGrow + ' ' + flexShrink + ' ' + properBasis(flexBasis);

--- a/bugs/bug6.js
+++ b/bugs/bug6.js
@@ -5,7 +5,7 @@ module.exports = function(decl) {
     var values = postcss.list.space(decl.value);
     var flexGrow = values[0];
     var flexShrink = values[1] || '1';
-    var flexBasis = values[2] || '0%';
+    var flexBasis = values.slice(2).join(' ') || '0%';
     // Safari seems to hate '0%' and the others seems to make do with a nice value when basis is missing,
     // so if we see a '0%', just remove it.  This way it'll get adjusted for any other cases where '0%' is
     // already defined somewhere else.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/luisrudge/postcss-flexbugs-fixes.git"
-    },    
+    },
     "main": "index.js",
     "files": [
         "bugs",
@@ -28,7 +28,9 @@
         "chai": "^4.2.0",
         "gulp": "^4.0.2",
         "gulp-eslint": "^6.0.0",
-        "gulp-mocha": "^7.0.2"
+        "gulp-mocha": "^7.0.2",
+        "postcss-less": "^5.0.0",
+        "postcss-scss": "^4.0.2"
     },
     "scripts": {
         "test": "gulp"

--- a/specs/bug4Spec.js
+++ b/specs/bug4Spec.js
@@ -32,6 +32,14 @@ describe('bug 4', function() {
     test(input, output, {}, done);
   });
   describe('does nothing', function() {
+    it('when flexBasis has operator wrapped by space if syntax is less', function(done) {
+      var less ='@vm:10px; .test{flex: 0 1 21 * @vm }'
+      test(less, less, {}, done, require('postcss-less'));
+    });
+    it('when flexBasis has operator wrapped by space if syntax is scss', function(done) {
+      var scss ='$vm:10px; .test{flex: 0 1 21 / $vm }'
+      test(scss, scss, {}, done, require('postcss-scss'));
+    });
     it('when not flex declarations', function(done) {
       var css = 'a{display: flex;}';
       test(css, css, {}, done);

--- a/specs/bug6Spec.js
+++ b/specs/bug6Spec.js
@@ -7,6 +7,14 @@ describe('bug 6', function() {
     test(input, output, {}, done);
   });
   describe('does nothing', function() {
+    it('when flexBasis has operator wrapped by space if syntax is less', function(done) {
+      var less ='@vm:10px; .test{flex: 0 1 21 * @vm }'
+      test(less, less, {}, done, require('postcss-less'));
+    });
+    it('when flexBasis has operator wrapped by space if syntax is scss', function(done) {
+      var scss ='$vm:10px; .test{flex: 0 1 21 / $vm }'
+      test(scss, scss, {}, done, require('postcss-scss'));
+    });
     it('when flex is set to none', function(done) {
       var css = 'div{flex: none;}';
       test(css, css, {}, done);

--- a/specs/test.js
+++ b/specs/test.js
@@ -2,9 +2,9 @@ var postcss = require('postcss');
 var expect = require('chai').expect;
 var plugin = require('../');
 
-module.exports = function(input, output, opts, done) {
+module.exports = function(input, output, opts, done, syntax) {
   postcss([plugin(opts)])
-    .process(input, {from: undefined})
+    .process(input, {from: undefined, syntax: syntax || undefined})
     .then(function(result) {
       expect(result.css).to.eql(output);
       expect(result.warnings()).to.be.empty;


### PR DESCRIPTION
I found that when the flex basis has operator wrapped by space if syntax is less/sass/scss ，the operator and subsequent variables will _**LOST**_ !!! ( [Reappeard Repo](https://github.com/RichieChoo/postcss-flexbugs-fixes-bug-demo) )

Here is the screenshot of debugging process.(_**The fourth and later children of values is lost**_ )
![image (1)](https://user-images.githubusercontent.com/17178139/141230785-4d523656-9fb1-4d5a-8a1b-910ef9256aef.png)

I fixed the bug in[ this commit](https://github.com/RichieChoo/postcss-flexbugs-fixes/commit/54866e5aaab2567c6cf09b26ff1ab8b2d0910350),  please review my code and test cases.
Please connact me if this pr has problem.
Thank you.